### PR TITLE
fix: Change way that loading icons is presented

### DIFF
--- a/fabtext/src/main/java/com/lucas/fabtext/FabText.kt
+++ b/fabtext/src/main/java/com/lucas/fabtext/FabText.kt
@@ -90,12 +90,7 @@ open class FabText : LinearLayout {
             isClickable = true
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            background = ContextCompat.getDrawable(context, R.drawable.fab_text_bg)
-        } else {
-            @Suppress("DEPRECATION")
-            setBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.fab_text_bg))
-        }
+        setBackgroundResource(R.drawable.fab_text_bg)
 
         fabImageView?.setImageDrawable(context.createVectorCompatDrawable(imageDrawable!!))
 
@@ -111,20 +106,13 @@ open class FabText : LinearLayout {
 
             fabTextView?.visibility = GONE
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                fabContainer?.background = ContextCompat.getDrawable(context, R.drawable.fab_bg)
-            } else {
-                @Suppress("DEPRECATION")
-                fabContainer?.setBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.fab_bg))
-            }
+            fabContainer?.setBackgroundResource(R.drawable.fab_bg)
 
             fabContainer?.background?.setColorFilter(Color.parseColor(if (backgroundColor.isNullOrEmpty()) {
                 "#ffffff"
             } else {
                 backgroundColor
             }), PorterDuff.Mode.SRC_ATOP)
-
-            fabImageView?.setPadding(8, 0, 0, 0)
         }
 
         fabContainer?.setOnClickListener {
@@ -142,21 +130,13 @@ open class FabText : LinearLayout {
 
         Handler().postDelayed({
             TransitionManager.beginDelayedTransition(this)
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                fabContainer?.background = ContextCompat.getDrawable(context, R.drawable.fab_bg)
-            } else {
-                @Suppress("DEPRECATION")
-                fabContainer?.setBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.fab_bg))
-            }
+            fabContainer?.setBackgroundResource(R.drawable.fab_bg)
 
             fabContainer?.background?.setColorFilter(Color.parseColor(if (backgroundColor.isNullOrEmpty()) {
                 "#ffffff"
             } else {
                 backgroundColor
             }), PorterDuff.Mode.SRC_ATOP)
-
-            fabImageView?.setPadding(8, 0, 0, 0)
         }, 200)
 
     }
@@ -166,25 +146,18 @@ open class FabText : LinearLayout {
             TransitionManager.beginDelayedTransition(this)
             fabTextView?.visibility = VISIBLE
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                fabContainer?.background = ContextCompat.getDrawable(context, R.drawable.fab_text_bg)
-            } else {
-                @Suppress("DEPRECATION")
-                fabContainer?.setBackgroundDrawable(ContextCompat.getDrawable(context, R.drawable.fab_text_bg))
-            }
+            fabContainer?.setBackgroundResource(R.drawable.fab_text_bg)
 
             fabContainer?.background?.setColorFilter(Color.parseColor(if (backgroundColor.isNullOrEmpty()) {
                 "#ffffff"
             } else {
                 backgroundColor
             }), PorterDuff.Mode.SRC_ATOP)
-
-            fabImageView?.setPadding(0, 0, 0, 0)
         }
     }
 
     fun startLoading() {
-        fabImageView?.setImageDrawable(context.createVectorCompatDrawable(R.drawable.dual_ring))
+        fabImageView?.setImageResource(R.drawable.dual_ring)
         fabContainer?.isEnabled = false
 
         val rotationAnimator = ObjectAnimator
@@ -199,7 +172,7 @@ open class FabText : LinearLayout {
     }
 
     fun finishLoading() {
-        fabImageView?.setImageDrawable(context.createVectorCompatDrawable(imageDrawable!!))
+        fabImageView?.setImageResource(imageDrawable!!)
         fabContainer?.isEnabled = true
         animatorSet.end()
     }

--- a/fabtext/src/main/res/layout/fab_text.xml
+++ b/fabtext/src/main/res/layout/fab_text.xml
@@ -7,17 +7,17 @@
                   android:id="@+id/fab_container"
                   android:orientation="horizontal"
                   android:background="@drawable/fab_text_bg"
+                  android:paddingLeft="16dp"
+                  android:paddingRight="16dp"
+                  android:layout_gravity="center_horizontal|center_vertical"
                   android:focusable="true"
-                  android:clickable="true"
-                  tools:ignore="UnusedAttribute">
+                  android:clickable="true">
         <ImageView
                 android:layout_width="24dp"
                 android:layout_height="24dp"
                 app:srcCompat="@drawable/ic_android_black_24dp"
                 android:tint="@android:color/white"
                 android:id="@+id/image_fab"
-                android:layout_marginLeft="@dimen/fab_inner_margin_left"
-                android:layout_marginStart="@dimen/fab_inner_margin_left"
                 android:layout_gravity="center"/>
         <TextView android:id="@+id/text_fab"
                   android:layout_width="wrap_content"
@@ -28,8 +28,6 @@
                   android:textAppearance="@style/TextAppearance.AppCompat.Button"
                   android:textColor="@android:color/white"
                   android:layout_marginLeft="@dimen/fab_inner_margin_left"
-                  android:layout_marginStart="@dimen/fab_inner_margin_left"
-                  android:layout_marginRight="@dimen/fab_inner_margin_right"
-                  android:layout_marginEnd="@dimen/fab_inner_margin_right"/>
+                  android:layout_marginStart="@dimen/fab_inner_margin_left"/>
     </LinearLayout>
 </merge>


### PR DESCRIPTION
On startLoading and stopLoading, the ring presenting was done as it was a XML drawable file and this breaks in devices with API < 21.

setBackground calls changed to use set BackgroundResource as the later is deprecated.

Resolves: #1